### PR TITLE
Add odometry to serial protocol

### DIFF
--- a/Arduino/hoverserial/hoverserial.ino
+++ b/Arduino/hoverserial/hoverserial.ino
@@ -55,6 +55,8 @@ typedef struct{
    int16_t  cmd2;
    int16_t  speedR_meas;
    int16_t  speedL_meas;
+   int16_t  wheelR_cnt;
+   int16_t  wheelL_cnt;
    int16_t  batVoltage;
    int16_t  boardTemp;
    uint16_t cmdLed;
@@ -122,7 +124,7 @@ void Receive()
     if (idx == sizeof(SerialFeedback)) {
         uint16_t checksum;
         checksum = (uint16_t)(NewFeedback.start ^ NewFeedback.cmd1 ^ NewFeedback.cmd2 ^ NewFeedback.speedR_meas ^ NewFeedback.speedL_meas
-                            ^ NewFeedback.batVoltage ^ NewFeedback.boardTemp ^ NewFeedback.cmdLed);
+                            ^ NewFeedback.wheelR_cnt ^ NewFeedback.wheelL_cnt ^ NewFeedback.batVoltage ^ NewFeedback.boardTemp ^ NewFeedback.cmdLed);
 
         // Check validity of the new data
         if (NewFeedback.start == START_FRAME && checksum == NewFeedback.checksum) {
@@ -134,6 +136,8 @@ void Receive()
             Serial.print(" 2: ");  Serial.print(Feedback.cmd2);
             Serial.print(" 3: ");  Serial.print(Feedback.speedR_meas);
             Serial.print(" 4: ");  Serial.print(Feedback.speedL_meas);
+            Serial.print(" r: ");  Serial.print(Feedback.wheelR_cnt);
+            Serial.print(" l: ");  Serial.print(Feedback.wheelL_cnt);
             Serial.print(" 5: ");  Serial.print(Feedback.batVoltage);
             Serial.print(" 6: ");  Serial.print(Feedback.boardTemp);
             Serial.print(" 7: ");  Serial.println(Feedback.cmdLed);

--- a/Arduino/hoverserial/hoverserial.ino
+++ b/Arduino/hoverserial/hoverserial.ino
@@ -27,11 +27,12 @@
 #define SERIAL_BAUD         115200      // [-] Baud rate for built-in Serial (used for the Serial Monitor)
 #define START_FRAME         0xABCD     	// [-] Start frme definition for reliable serial communication
 #define TIME_SEND           100         // [ms] Sending time interval
-#define SPEED_MAX_TEST      300         // [-] Maximum speed for testing
+#define SPEED_MAX_TEST      100         // [-] Maximum speed for testing
 // #define DEBUG_RX                        // [-] Debug received data. Prints all bytes to serial (comment-out to disable)
 
 #include <SoftwareSerial.h>
 SoftwareSerial HoverSerial(2,3);        // RX, TX
+//SoftwareSerial HoverSerial2(4,5);        // RX, TX
 
 // Global variables
 uint8_t idx = 0;                        // Index for new data pointer
@@ -69,6 +70,8 @@ void setup()
   Serial.println("Hoverboard Serial v1.0");
 
   HoverSerial.begin(HOVER_SERIAL_BAUD);
+  //HoverSerial2.begin(HOVER_SERIAL_BAUD);
+  
   pinMode(LED_BUILTIN, OUTPUT);
 }
 
@@ -82,7 +85,8 @@ void Send(int16_t uSteer, int16_t uSpeed)
   Command.checksum = (uint16_t)(Command.start ^ Command.steer ^ Command.speed);
 
   // Write to Serial
-  HoverSerial.write((uint8_t *) &Command, sizeof(Command)); 
+  HoverSerial.write((uint8_t *) &Command, sizeof(Command));
+  //HoverSerial2.write((uint8_t *) &Command, sizeof(Command)); 
 }
 
 // ########################## RECEIVE ##########################
@@ -159,10 +163,12 @@ void loop(void)
   // Send commands
   if (iTimeSend > timeNow) return;
   iTimeSend = timeNow + TIME_SEND;
-  Send(0, SPEED_MAX_TEST - 2*abs(iTest));
+  int power = (SPEED_MAX_TEST - 2*abs(iTest));
+  Send(0, power);
+  //Serial.println(power);
 
   // Calculate test command signal
-  iTest += 10;
+  iTest += 1;
   if (iTest > iTestMax) iTest = -iTestMax;
 
   // Blink the LED

--- a/Arduino/hoverserial/hoverserial.ino
+++ b/Arduino/hoverserial/hoverserial.ino
@@ -32,7 +32,6 @@
 
 #include <SoftwareSerial.h>
 SoftwareSerial HoverSerial(2,3);        // RX, TX
-//SoftwareSerial HoverSerial2(4,5);        // RX, TX
 
 // Global variables
 uint8_t idx = 0;                        // Index for new data pointer
@@ -72,7 +71,6 @@ void setup()
   Serial.println("Hoverboard Serial v1.0");
 
   HoverSerial.begin(HOVER_SERIAL_BAUD);
-  //HoverSerial2.begin(HOVER_SERIAL_BAUD);
   
   pinMode(LED_BUILTIN, OUTPUT);
 }
@@ -88,7 +86,6 @@ void Send(int16_t uSteer, int16_t uSpeed)
 
   // Write to Serial
   HoverSerial.write((uint8_t *) &Command, sizeof(Command));
-  //HoverSerial2.write((uint8_t *) &Command, sizeof(Command)); 
 }
 
 // ########################## RECEIVE ##########################
@@ -167,10 +164,8 @@ void loop(void)
   // Send commands
   if (iTimeSend > timeNow) return;
   iTimeSend = timeNow + TIME_SEND;
-  int power = (SPEED_MAX_TEST - 2*abs(iTest));
-  Send(0, power);
-  //Serial.println(power);
-
+  Send(0, SPEED_MAX_TEST - 2*abs(iTest));
+  
   // Calculate test command signal
   iTest += 1;
   if (iTest > iTestMax) iTest = -iTestMax;

--- a/Src/bldc.c
+++ b/Src/bldc.c
@@ -212,15 +212,12 @@ void DMA1_Channel1_IRQHandler(void) {
   // errCodeLeft  = rtY_Left.z_errCode;
   // motSpeedLeft = rtY_Left.n_mot;
   // motAngleLeft = rtY_Left.a_elecAngle;
-  uint8_t encoding = (uint8_t)((hall_ul<<2) + (hall_vl<<1) + hall_wl);
-  int wheel_pos = rtConstP.vec_hallToPos_Value[encoding];
+    uint8_t encoding = (uint8_t)((hall_ul<<2) + (hall_vl<<1) + hall_wl);
+    int wheel_pos = rtConstP.vec_hallToPos_Value[encoding];
   
-  odom_l = odom_l + up_or_down(wp_l_vorher, wheel_pos);
-  wp_l_vorher = wheel_pos;
+    odom_l = odom_l + up_or_down(wp_l_vorher, wheel_pos);
+    wp_l_vorher = wheel_pos;
   
-  //odom_l = odom_l + (int)((elecAngle_l_vorher + dist - rtY_Left.a_elecAngle) % 6 == 0 ? dist : -dist);
-  //elecAngle_l_vorher = rtY_Left.a_elecAngle;
-
     /* Apply commands */
     LEFT_TIM->LEFT_TIM_U    = (uint16_t)CLAMP(ul + pwm_res / 2, pwm_margin, pwm_res-pwm_margin);
     LEFT_TIM->LEFT_TIM_V    = (uint16_t)CLAMP(vl + pwm_res / 2, pwm_margin, pwm_res-pwm_margin);
@@ -259,11 +256,11 @@ void DMA1_Channel1_IRQHandler(void) {
  // motSpeedRight = rtY_Right.n_mot;
  // motAngleRight = rtY_Right.a_elecAngle;
 
-  encoding = (uint8_t)((hall_ur<<2) + (hall_vr<<1) + hall_wr);
-  wheel_pos = rtConstP.vec_hallToPos_Value[encoding];
+    encoding = (uint8_t)((hall_ur<<2) + (hall_vr<<1) + hall_wr);
+    wheel_pos = rtConstP.vec_hallToPos_Value[encoding];
   
-  odom_r = odom_r - up_or_down(wp_r_vorher, wheel_pos);
-  wp_r_vorher = wheel_pos;
+    odom_r = odom_r - up_or_down(wp_r_vorher, wheel_pos);
+    wp_r_vorher = wheel_pos;
 
     /* Apply commands */
     RIGHT_TIM->RIGHT_TIM_U  = (uint16_t)CLAMP(ur + pwm_res / 2, pwm_margin, pwm_res-pwm_margin);

--- a/Src/bldc.c
+++ b/Src/bldc.c
@@ -87,11 +87,15 @@ int16_t odom_r = 0;
 static uint16_t wp_l_vorher = 0;
 static uint16_t wp_r_vorher = 0;
 
+int16_t modulo(int16_t m, int16_t rest_classes){
+  return (((m % rest_classes) + rest_classes) %rest_classes);
+}
+
 int16_t up_or_down(int16_t vorher, int16_t nachher){
   uint16_t up_down[6] = {0,-1,-2,0,2,1};
-  uint16_t mod_diff =  (((vorher - nachher) % 6) + 6) % 6;
+  //uint16_t mod_diff =  (((vorher - nachher) % 6) + 6) % 6;
   
-  return up_down[mod_diff];
+  return up_down[modulo(vorher-nachher, 6)];
 }
 
 // =================================
@@ -215,7 +219,7 @@ void DMA1_Channel1_IRQHandler(void) {
   uint8_t encoding = (uint8_t)((hall_ul<<2) + (hall_vl<<1) + hall_wl);
   int wheel_pos = rtConstP.vec_hallToPos_Value[encoding];
   
-  odom_l = odom_l + up_or_down(wp_l_vorher, wheel_pos);
+  odom_l = modulo(odom_l + up_or_down(wp_l_vorher, wheel_pos), 9000);
   wp_l_vorher = wheel_pos;
   
   //odom_l = odom_l + (int)((elecAngle_l_vorher + dist - rtY_Left.a_elecAngle) % 6 == 0 ? dist : -dist);
@@ -262,7 +266,7 @@ void DMA1_Channel1_IRQHandler(void) {
   encoding = (uint8_t)((hall_ur<<2) + (hall_vr<<1) + hall_wr);
   wheel_pos = rtConstP.vec_hallToPos_Value[encoding];
   
-  odom_r = odom_r - up_or_down(wp_r_vorher, wheel_pos);
+  odom_r = modulo(odom_r - up_or_down(wp_r_vorher, wheel_pos), 9000);
   wp_r_vorher = wheel_pos;
 
     /* Apply commands */

--- a/Src/main.c
+++ b/Src/main.c
@@ -113,6 +113,9 @@ int16_t dc_curr;                 // global variable for Total DC Link current
 int16_t cmdL;                    // global variable for Left Command 
 int16_t cmdR;                    // global variable for Right Command 
 
+extern int16_t odom_r;
+extern int16_t odom_l;
+
 //------------------------------------------------------------------------
 // Local variables
 //------------------------------------------------------------------------
@@ -456,8 +459,8 @@ int main(void) {
         Feedback.start	        = (uint16_t)SERIAL_START_FRAME;
         Feedback.cmd1           = (int16_t)input1[inIdx].cmd;
         Feedback.cmd2           = (int16_t)input2[inIdx].cmd;
-        Feedback.speedR_meas	  = (int16_t)rtY_Right.n_mot;
-        Feedback.speedL_meas	  = (int16_t)rtY_Left.n_mot;
+        Feedback.speedR_meas	  = (int16_t)odom_r; //rtY_Right.a_elecAngle;//rtU_Right.a_mechAngle; //rtY_Right.a_elecAngle; //n_mot;
+        Feedback.speedL_meas	  = (int16_t)odom_l; //rtY_Left.a_elecAngle; //mechAngle; //elecAngle; //n_mot;
         Feedback.batVoltage	    = (int16_t)batVoltageCalib;
         Feedback.boardTemp	    = (int16_t)board_temp_deg_c;
 

--- a/Src/main.c
+++ b/Src/main.c
@@ -126,6 +126,8 @@ typedef struct{
   int16_t   cmd2;
   int16_t   speedR_meas;
   int16_t   speedL_meas;
+  int16_t   wheelR_cnt;
+  int16_t   wheelL_cnt;
   int16_t   batVoltage;
   int16_t   boardTemp;
   uint16_t  cmdLed;
@@ -459,8 +461,10 @@ int main(void) {
         Feedback.start	        = (uint16_t)SERIAL_START_FRAME;
         Feedback.cmd1           = (int16_t)input1[inIdx].cmd;
         Feedback.cmd2           = (int16_t)input2[inIdx].cmd;
-        Feedback.speedR_meas	  = (int16_t)odom_r; //rtY_Right.a_elecAngle;//rtU_Right.a_mechAngle; //rtY_Right.a_elecAngle; //n_mot;
-        Feedback.speedL_meas	  = (int16_t)odom_l; //rtY_Left.a_elecAngle; //mechAngle; //elecAngle; //n_mot;
+        Feedback.speedR_meas	  = (int16_t)rtY_Right.n_mot;
+        Feedback.speedL_meas	  = (int16_t)rtY_Left.n_mot;
+        Feedback.wheelR_cnt     = (int16_t)odom_r;
+        Feedback.wheelL_cnt     = (int16_t)odom_l;
         Feedback.batVoltage	    = (int16_t)batVoltageCalib;
         Feedback.boardTemp	    = (int16_t)board_temp_deg_c;
 
@@ -468,7 +472,7 @@ int main(void) {
           if(__HAL_DMA_GET_COUNTER(huart2.hdmatx) == 0) {
             Feedback.cmdLed     = (uint16_t)sideboard_leds_L;
             Feedback.checksum   = (uint16_t)(Feedback.start ^ Feedback.cmd1 ^ Feedback.cmd2 ^ Feedback.speedR_meas ^ Feedback.speedL_meas 
-                                           ^ Feedback.batVoltage ^ Feedback.boardTemp ^ Feedback.cmdLed);
+                                           ^ Feedback.wheelR_cnt ^ Feedback.wheelL_cnt ^ Feedback.batVoltage ^ Feedback.boardTemp ^ Feedback.cmdLed);
 
             HAL_UART_Transmit_DMA(&huart2, (uint8_t *)&Feedback, sizeof(Feedback));
           }


### PR DESCRIPTION
Odometry is calculated and reported in the serial protocol as wheelR_cnt and wheelL_cnt. Value range [0, 9000), then it wraps around. Odometry is reported in encoder ticks, one full rotation of the wheel is 90 ticks.
Implementation by @ducktrA.
